### PR TITLE
Add overflow-safe uptime tracking

### DIFF
--- a/ByteTransmission.h
+++ b/ByteTransmission.h
@@ -7,6 +7,7 @@
 #include "config.h"
 #include "secrets.h"
 #include "SensorManager.h"
+#include "TimeUtils.h"
 
 // ===== BYTE TRANSMISSION PROTOCOL =====
 // Kompaktes Binärformat für minimale Datenübertragung
@@ -131,7 +132,7 @@ SensorDataPacket ByteTransmissionManager::createPacket(const SensorData& data) {
   SensorDataPacket packet = {0};
   
   // Header
-  packet.timestamp = millis() / 1000;  // Unix-ähnlich
+  packet.timestamp = (uint32_t)(getUptimeMillis() / 1000);  // Unix-like since start
   
   // BME68X Daten
   if (data.bme68xAvailable) {
@@ -164,7 +165,7 @@ SensorDataPacket ByteTransmissionManager::createPacket(const SensorData& data) {
   }
   
   // System Daten
-  packet.uptime_seconds = millis() / 1000;  // Sekunden seit Start
+  packet.uptime_seconds = (uint32_t)(getUptimeMillis() / 1000);  // Seconds since start
   packet.wifi_rssi = (int8_t)WiFi.RSSI();
   
   // Checksumme berechnen

--- a/DisplayManager.h
+++ b/DisplayManager.h
@@ -6,6 +6,7 @@
 #include <Adafruit_NeoPixel.h>
 #include "config.h"
 #include "SensorManager.h"
+#include "TimeUtils.h"
 
 // ===== DISPLAY MANAGER CLASS =====
 class DisplayManager {
@@ -270,7 +271,7 @@ void DisplayManager::drawSystem(const SensorData& data, bool wifiConnected, bool
   
   // Uptime formatiert
   display.setCursor(0, 25);
-  unsigned long uptimeSeconds = millis() / 1000;
+  uint64_t uptimeSeconds = getUptimeMillis() / 1000;
   unsigned long days = uptimeSeconds / 86400;
   unsigned long hours = (uptimeSeconds % 86400) / 3600;
   unsigned long minutes = (uptimeSeconds % 3600) / 60;

--- a/TimeUtils.h
+++ b/TimeUtils.h
@@ -1,0 +1,17 @@
+#ifndef TIME_UTILS_H
+#define TIME_UTILS_H
+
+#include <Arduino.h>
+
+// Returns system uptime in milliseconds, handling millis() overflow
+inline uint64_t getUptimeMillis() {
+  static uint32_t last = 0;
+  static uint64_t total = 0;
+
+  uint32_t now = millis();
+  total += (uint32_t)(now - last);
+  last = now;
+  return total;
+}
+
+#endif

--- a/WiFiManager.h
+++ b/WiFiManager.h
@@ -8,6 +8,7 @@
 #include "config.h"
 #include "secrets.h"
 #include "SensorManager.h"
+#include "TimeUtils.h"
 
 // ===== AQI RESULT STRUCTURE =====
 struct AQIResult {
@@ -91,8 +92,8 @@ bool WiFiManager::sendSensorData(const SensorData& data) {
   DynamicJsonDocument doc(1536); // Größer für mehr Daten
   
   // Timestamp
-  doc["timestamp"] = millis();
-  doc["uptime"] = millis() / 1000;
+    doc["timestamp"] = getUptimeMillis();
+    doc["uptime"] = getUptimeMillis() / 1000;
   
   // BME68X BSEC Daten
   if (data.bme68xAvailable) {


### PR DESCRIPTION
## Summary
- add utility to track uptime beyond `millis()` overflow
- use overflow-safe uptime in display, WiFi JSON payloads and binary packet

## Testing
- `arduino-cli --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*
- `pip install platformio` *(fails: tunnel connection 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a205a9a97083249fd86b8ad5bf4121