### PR TITLE
fix: stabilize MQTT discovery and add BME68X I2C diagnostics

### DIFF
--- a/AirQualityMonitor.ino
+++ b/AirQualityMonitor.ino
@@ -105,7 +105,7 @@ void setup() {
     String ip = wifiManager.getIPAddress();
     displayManager.showMessage("IP: " + ip, 2000);
     DEBUG_INFO("WiFi connected successfully");
-    
+
     // Initialize MQTT
     mqttManager.init();
     if (mqttManager.connect()) {

--- a/MQTTManager.h
+++ b/MQTTManager.h
@@ -30,7 +30,11 @@ private:
   unsigned long lastReconnectAttempt = 0;
   unsigned long lastStatusUpdate = 0;
   unsigned long lastDiscoveryPublish = 0;
+  unsigned long lastConnectTime = 0;            // When connect() succeeded (for discovery delay)
+  unsigned long nextDiscoveryRetryAt = 0;      // Retry discovery at this time (backoff after abort)
+  bool hasEverConnected = false;                // True after first successful connect (avoid discovery loop on reconnect)
   bool discoveryPublished = false;
+  bool discoveryRequestedAfterConnect = false;  // Defer discovery to update() for stable connection
   String deviceUniqueId;
   String baseTopic;
   String discoveryPrefix;
@@ -205,6 +209,8 @@ bool MQTTManager::publishSensorDiscovery(const String& sensorName, const String&
   serializeJson(config, payload);
   
   bool published = mqttClient.publish(topic.c_str(), payload.c_str(), true); // retain = true
+  mqttClient.loop();
+  delay(100);  // Allow broker to process; 100 ms for brokers that drop under rapid publish (e.g. port 403)
   if (published) {
     DEBUG_INFO("Published discovery for %s", sensorName.c_str());
   } else {
@@ -278,6 +284,8 @@ bool MQTTManager::publishBinarySensorDiscovery(const String& sensorName, const S
   serializeJson(config, payload);
   
   bool published = mqttClient.publish(topic.c_str(), payload.c_str(), true); // retain = true
+  mqttClient.loop();
+  delay(100);  // Allow broker to process; 100 ms for brokers that drop under rapid publish
   if (published) {
     DEBUG_INFO("Published binary sensor discovery for %s", sensorName.c_str());
   } else {
@@ -319,17 +327,28 @@ void MQTTManager::publishDiscoveryConfig() {
   bool allOk = true;
   int successCount = 0;
   int failCount = 0;
+  bool discoveryAborted = false;
+  
+  #define DISCOVERY_CHECK_CONNECTED() do { \
+    mqttClient.loop(); \
+    if (!mqttClient.connected()) { \
+      DEBUG_WARN("MQTT disconnected during discovery - stopping. Will retry on next connect."); \
+      discoveryAborted = true; \
+      goto discovery_end; \
+    } \
+  } while(0)
   
   // Environmental sensors
   if (true) { // Always publish, Home Assistant will handle availability
+    DISCOVERY_CHECK_CONNECTED();
     if (publishSensorDiscovery("temperature", "temperature", "°C", "mdi:thermometer")) successCount++; else failCount++;
     if (publishSensorDiscovery("humidity", "humidity", "%", "mdi:water-percent")) successCount++; else failCount++;
     if (publishSensorDiscovery("pressure", "pressure", "hPa", "mdi:gauge")) successCount++; else failCount++;
     if (publishSensorDiscovery("external_temperature", "temperature", "°C", "mdi:thermometer")) successCount++; else failCount++;
-    mqttClient.loop(); // Process MQTT messages
   }
   
   // Air quality sensors
+  DISCOVERY_CHECK_CONNECTED();
   if (publishSensorDiscovery("iaq", "", "", "mdi:air-filter")) successCount++; else failCount++;
   if (publishSensorDiscovery("iaq_accuracy", "", "", "mdi:check-circle")) successCount++; else failCount++;
   if (publishSensorDiscovery("static_iaq", "", "", "mdi:air-filter")) successCount++; else failCount++;
@@ -339,29 +358,31 @@ void MQTTManager::publishDiscoveryConfig() {
   if (publishSensorDiscovery("voc", "volatile_organic_compounds", "mg/m³", "mdi:air-filter")) successCount++; else failCount++;
   if (publishSensorDiscovery("voc_accuracy", "", "", "mdi:check-circle")) successCount++; else failCount++;
   if (publishSensorDiscovery("gas_resistance", "", "Ω", "mdi:gauge")) successCount++; else failCount++;
-  mqttClient.loop(); // Process MQTT messages
   
   // Particulate matter sensors
+  DISCOVERY_CHECK_CONNECTED();
   if (publishSensorDiscovery("pm1_0", "pm1", "µg/m³", "mdi:air-filter")) successCount++; else failCount++;
   if (publishSensorDiscovery("pm2_5", "pm25", "µg/m³", "mdi:air-filter")) successCount++; else failCount++;
   if (publishSensorDiscovery("pm10", "pm10", "µg/m³", "mdi:air-filter")) successCount++; else failCount++;
   
   // Calculated comfort values
+  DISCOVERY_CHECK_CONNECTED();
   if (publishSensorDiscovery("dew_point", "temperature", "°C", "mdi:thermometer-water")) successCount++; else failCount++;
   if (publishSensorDiscovery("heat_index", "temperature", "°C", "mdi:thermometer")) successCount++; else failCount++;
   if (publishSensorDiscovery("absolute_humidity", "", "g/m³", "mdi:water")) successCount++; else failCount++;
   if (publishSensorDiscovery("comfort_index", "", "", "mdi:sofa")) successCount++; else failCount++;
   
   // AQI values
+  DISCOVERY_CHECK_CONNECTED();
   if (publishSensorDiscovery("aqi_index", "", "", "mdi:air-filter")) successCount++; else failCount++;
   if (publishSensorDiscovery("aqi_category", "", "", "mdi:information")) successCount++; else failCount++;
   if (publishSensorDiscovery("pm2_5_aqi", "", "", "mdi:air-filter")) successCount++; else failCount++;
   if (publishSensorDiscovery("pm10_aqi", "", "", "mdi:air-filter")) successCount++; else failCount++;
   if (publishSensorDiscovery("iaq_aqi", "", "", "mdi:air-filter")) successCount++; else failCount++;
   if (publishSensorDiscovery("bsec_calibrated", "", "", "mdi:check-circle")) successCount++; else failCount++;
-  mqttClient.loop(); // Process MQTT messages
   
   // System sensors
+  DISCOVERY_CHECK_CONNECTED();
   if (publishSensorDiscovery("wifi_rssi", "signal_strength", "dBm", "mdi:wifi")) successCount++; else failCount++;
   if (publishSensorDiscovery("wifi_connected", "", "", "mdi:wifi")) successCount++; else failCount++;
   if (publishSensorDiscovery("mqtt_connected", "", "", "mdi:server-network")) successCount++; else failCount++;
@@ -378,9 +399,9 @@ void MQTTManager::publishDiscoveryConfig() {
   if (publishSensorDiscovery("sensor_reliable", "", "", "mdi:check-circle")) successCount++; else failCount++;
   if (publishSensorDiscovery("bme68x_stable", "", "", "mdi:check-circle")) successCount++; else failCount++;
   if (publishSensorDiscovery("bme68x_runin_complete", "", "", "mdi:check-circle")) successCount++; else failCount++;
-  mqttClient.loop(); // Process MQTT messages
   
   // Alert binary sensors
+  DISCOVERY_CHECK_CONNECTED();
   if (publishBinarySensorDiscovery("alert_aqi", "problem", "mdi:alert")) successCount++; else failCount++;
   if (publishBinarySensorDiscovery("alert_co2", "problem", "mdi:alert")) successCount++; else failCount++;
   if (publishBinarySensorDiscovery("alert_pm25", "problem", "mdi:alert")) successCount++; else failCount++;
@@ -390,16 +411,23 @@ void MQTTManager::publishDiscoveryConfig() {
   if (publishBinarySensorDiscovery("ventilation_needed", "", "mdi:fan")) successCount++; else failCount++;
   
   // Additional sensor values
+  DISCOVERY_CHECK_CONNECTED();
   if (publishSensorDiscovery("tvoc_ppb", "", "ppb", "mdi:air-filter")) successCount++; else failCount++;
   if (publishSensorDiscovery("tvoc_mgm3", "", "mg/m³", "mdi:air-filter")) successCount++; else failCount++;
   if (publishSensorDiscovery("aqi_color_code", "", "", "mdi:palette")) successCount++; else failCount++;
   
+discovery_end:
+  #undef DISCOVERY_CHECK_CONNECTED
+  // If discovery aborted due to disconnect, retry after 60 s (backoff to avoid 2s loop)
+  if (discoveryAborted) {
+    nextDiscoveryRetryAt = now + 60000;
+  }
   // Final loop to ensure all messages are sent
   mqttClient.loop();
   delay(100); // Small delay to allow messages to be sent
   mqttClient.loop();
   
-  allOk = (failCount == 0);
+  allOk = (failCount == 0 && !discoveryAborted);
   
   if (allOk) {
     discoveryPublished = true;
@@ -476,20 +504,14 @@ bool MQTTManager::connect() {
   
   if (connected) {
     DEBUG_INFO("MQTT connected successfully with LWT");
+    lastConnectTime = millis();
     publishAvailability();
-    
-    // Publish discovery config after connection - always try if not published
-    // Add a small delay to ensure connection is stable
-    delay(200); // Increased delay for stability
-    
-    // Force discovery republish if not already published
-    if (!discoveryPublished) {
-      DEBUG_INFO("Triggering discovery publish after MQTT connection");
-      publishDiscoveryConfig();
-    } else {
-      DEBUG_INFO("Discovery already published (discoveryPublished=true), skipping");
+    // Only request discovery on first connect (not on reconnect) to avoid 2s online/offline loop
+    if (!discoveryPublished && !hasEverConnected) {
+      discoveryRequestedAfterConnect = true;
+      DEBUG_INFO("Discovery will run after 2s stabilization");
     }
-    
+    hasEverConnected = true;
     return true;
   } else {
     DEBUG_ERROR("MQTT connection failed, state: %d", mqttClient.state());
@@ -505,8 +527,7 @@ void MQTTManager::reconnect() {
   
   lastReconnectAttempt = now;
   
-  // Reset discovery flag before reconnecting to ensure republish
-  discoveryPublished = false;
+  // Do not reset discoveryPublished here - avoids immediate discovery on reconnect and 2s online/offline loop
   
   // Publish offline before reconnecting (if we were connected before)
   // Note: This might not always work if connection is already lost, but LWT will handle it
@@ -527,6 +548,22 @@ void MQTTManager::update() {
     mqttClient.loop();
     
     unsigned long now = millis();
+    
+    // Run deferred discovery from connect() after stabilization delay (2s)
+    if (discoveryRequestedAfterConnect && mqttClient.connected()) {
+      const unsigned long kDiscoveryStabilizationMs = 2000;
+      if (now - lastConnectTime >= kDiscoveryStabilizationMs) {
+        discoveryRequestedAfterConnect = false;
+        DEBUG_INFO("Triggering discovery publish (after %lu s stabilization)", (unsigned long)(kDiscoveryStabilizationMs / 1000));
+        publishDiscoveryConfig();
+      }
+    }
+    // Retry discovery with 60 s backoff when previous run aborted due to disconnect
+    if (!discoveryPublished && nextDiscoveryRetryAt > 0 && now >= nextDiscoveryRetryAt && mqttClient.connected()) {
+      nextDiscoveryRetryAt = now + 60000;
+      DEBUG_INFO("Triggering discovery retry (backoff)");
+      publishDiscoveryConfig();
+    }
     
     // Send keep-alive status update every 60 seconds
     if (now - lastStatusUpdate >= 60000) { // 60 seconds

--- a/SensorManager.h
+++ b/SensorManager.h
@@ -127,6 +127,7 @@ public:
 
 private:
   bool scanI2CDevice(uint8_t address);
+  void scanI2CBus();  // Log all I2C addresses found (for diagnostics)
   bool initBME68X(uint8_t address);
   void configureBsecSensors();
   bool initDS18B20();
@@ -167,8 +168,11 @@ bool SensorManager::init() {
   }
 
   bool success = true;
-  
-  // Initialize BME68X
+
+  // Short delay so BME68X can power up (same I2C bus as display)
+  delay(150);
+
+  // Initialize BME68X (address 0x76 or 0x77 depending on SDO pin)
   uint8_t bmeAddress = 0;
   if (scanI2CDevice(BME68X_I2C_ADDR_HIGH)) {
     bmeAddress = BME68X_I2C_ADDR_HIGH;
@@ -179,7 +183,8 @@ bool SensorManager::init() {
   if (bmeAddress != 0) {
     success &= initBME68X(bmeAddress);
   } else {
-    DEBUG_ERROR("BME68X not found");
+    DEBUG_ERROR("BME68X not found at 0x%02X or 0x%02X", BME68X_I2C_ADDR_LOW, BME68X_I2C_ADDR_HIGH);
+    scanI2CBus();  // Show which I2C devices are present
     currentData.bme68xAvailable = false;
   }
   
@@ -258,6 +263,23 @@ bool SensorManager::update() {
 bool SensorManager::scanI2CDevice(uint8_t address) {
   Wire.beginTransmission(address);
   return (Wire.endTransmission() == 0);
+}
+
+void SensorManager::scanI2CBus() {
+  DEBUG_INFO("I2C bus scan (SDA=%d, SCL=%d):", DISPLAY_SDA, DISPLAY_SCL);
+  uint8_t count = 0;
+  for (uint8_t addr = 0x08; addr <= 0x77; addr++) {
+    Wire.beginTransmission(addr);
+    if (Wire.endTransmission() == 0) {
+      DEBUG_INFO("  Device at 0x%02X", addr);
+      count++;
+    }
+  }
+  if (count == 0) {
+    DEBUG_WARN("  No I2C devices found - check wiring and power");
+  } else {
+    DEBUG_INFO("  Total: %u device(s) - BME680 expected at 0x76 or 0x77", count);
+  }
 }
 
 bool SensorManager::initBME68X(uint8_t address) {

--- a/config.h
+++ b/config.h
@@ -20,23 +20,31 @@
 #define PMS_TX_PIN 17
 #define DS18B20_PIN 27  // GPIO27 (original configuration retained)
 
+// BME680/BME688 I2C addresses (standard: 0x76 with SDO low, 0x77 with SDO high)
+#ifndef BME68X_I2C_ADDR_LOW
+#define BME68X_I2C_ADDR_LOW 0x76
+#endif
+#ifndef BME68X_I2C_ADDR_HIGH
+#define BME68X_I2C_ADDR_HIGH 0x77
+#endif
+
 // Button - only use select
 #define BUTTON_SELECT_PIN 33
 #define BUTTON_DEBOUNCE_MS 50
 #define BUTTON_LONG_PRESS_MS 2000
 
 // ===== TIMING CONFIGURATION =====
-#define DATA_SEND_INTERVAL 10000      // 10 seconds
-#define SENSOR_READ_INTERVAL 3000     // 3 seconds (BSEC ULP mode compromise)
-#define WIFI_CONNECT_TIMEOUT 8000     // 8 seconds
-#define STEALTH_TEMP_ON_MS 20000      // 20 seconds temporary activation
-#define LED_TRANSITION_STEPS 20       // Number of steps for smooth color transition
-#define LED_TRANSITION_INTERVAL_MS 50 // Time between transition steps (ms)
+#define DATA_SEND_INTERVAL 10000       // 10 seconds
+#define SENSOR_READ_INTERVAL 3000      // 3 seconds (BSEC ULP mode compromise)
+#define WIFI_CONNECT_TIMEOUT 8000      // 8 seconds
+#define STEALTH_TEMP_ON_MS 20000       // 20 seconds temporary activation
+#define LED_TRANSITION_STEPS 20        // Number of steps for smooth color transition
+#define LED_TRANSITION_INTERVAL_MS 50  // Time between transition steps (ms)
 
 // ===== MQTT CONFIGURATION =====
-#define MQTT_PUBLISH_INTERVAL 10000   // 10 seconds (synchronized with DATA_SEND_INTERVAL)
-#define MQTT_RECONNECT_INTERVAL 5000  // 5 seconds between reconnect attempts
-#define MQTT_MAX_PACKET_SIZE 2048     // Maximum MQTT packet size (bytes)
+#define MQTT_PUBLISH_INTERVAL 10000           // 10 seconds (synchronized with DATA_SEND_INTERVAL)
+#define MQTT_RECONNECT_INTERVAL 5000          // 5 seconds between reconnect attempts
+#define MQTT_MAX_PACKET_SIZE 2048             // Maximum MQTT packet size (bytes)
 #define DISCOVERY_REPUBLISH_INTERVAL 3600000  // 60 minutes (ms) - republish discovery config periodically
 
 // ===== SENSOR CONFIGURATION =====
@@ -48,55 +56,55 @@
 #define BSEC_BASELINE_EEPROM_ADDR 0
 
 // Config storage in EEPROM (after BSEC state)
-#define CONFIG_EEPROM_ADDR 512             // Start address for config storage
-#define CONFIG_EEPROM_SIZE 256             // Size allocated for config (max 512 total)
+#define CONFIG_EEPROM_ADDR 512  // Start address for config storage
+#define CONFIG_EEPROM_SIZE 256  // Size allocated for config (max 512 total)
 
 // ===== VALIDATION CONSTANTS =====
 // Sensor value ranges for plausibility checks
-#define TEMP_MIN -40.0f          // Minimum valid temperature (°C)
-#define TEMP_MAX 85.0f           // Maximum valid temperature (°C)
-#define HUMIDITY_MIN 0.0f        // Minimum valid humidity (%)
-#define HUMIDITY_MAX 100.0f      // Maximum valid humidity (%)
-#define PRESSURE_MIN 300.0f      // Minimum valid pressure (hPa)
-#define PRESSURE_MAX 1100.0f     // Maximum valid pressure (hPa)
-#define IAQ_MIN 0.0f             // Minimum valid IAQ
-#define IAQ_MAX 500.0f           // Maximum valid IAQ
-#define CO2_MIN 400.0f           // Minimum valid CO2 (ppm)
-#define CO2_MAX 40000.0f         // Maximum valid CO2 (ppm)
-#define VOC_MIN 0.0f             // Minimum valid VOC (mg/m³)
-#define VOC_MAX 60.0f            // Maximum valid VOC (mg/m³)
-#define PM_MIN 0                 // Minimum valid PM value (µg/m³)
-#define PM_MAX 1000              // Maximum valid PM value (µg/m³)
+#define TEMP_MIN -40.0f       // Minimum valid temperature (°C)
+#define TEMP_MAX 85.0f        // Maximum valid temperature (°C)
+#define HUMIDITY_MIN 0.0f     // Minimum valid humidity (%)
+#define HUMIDITY_MAX 100.0f   // Maximum valid humidity (%)
+#define PRESSURE_MIN 300.0f   // Minimum valid pressure (hPa)
+#define PRESSURE_MAX 1100.0f  // Maximum valid pressure (hPa)
+#define IAQ_MIN 0.0f          // Minimum valid IAQ
+#define IAQ_MAX 500.0f        // Maximum valid IAQ
+#define CO2_MIN 400.0f        // Minimum valid CO2 (ppm)
+#define CO2_MAX 40000.0f      // Maximum valid CO2 (ppm)
+#define VOC_MIN 0.0f          // Minimum valid VOC (mg/m³)
+#define VOC_MAX 60.0f         // Maximum valid VOC (mg/m³)
+#define PM_MIN 0              // Minimum valid PM value (µg/m³)
+#define PM_MAX 1000           // Maximum valid PM value (µg/m³)
 
 // HTTP/Network constants
-#define HTTP_MAX_RESPONSE_SIZE 1024        // Maximum HTTP response size (bytes)
-#define HTTP_TIMEOUT_MS 5000               // HTTP request timeout (ms)
-#define HTTP_AQI_TIMEOUT_MS 3000           // AQI request timeout (ms)
-#define JSON_MAX_SIZE 256                  // Maximum JSON document size (bytes)
+#define HTTP_MAX_RESPONSE_SIZE 1024  // Maximum HTTP response size (bytes)
+#define HTTP_TIMEOUT_MS 5000         // HTTP request timeout (ms)
+#define HTTP_AQI_TIMEOUT_MS 3000     // AQI request timeout (ms)
+#define JSON_MAX_SIZE 256            // Maximum JSON document size (bytes)
 
 // PMS5003 constants
-#define PMS_READ_TIMEOUT_MS 1000           // PMS5003 read timeout (ms)
-#define PMS_WAKE_TIME_MS 2000              // PMS5003 wake time (ms)
-#define PMS_RETRY_COUNT 2                  // Maximum retry attempts for PMS5003
+#define PMS_READ_TIMEOUT_MS 1000  // PMS5003 read timeout (ms)
+#define PMS_WAKE_TIME_MS 2000     // PMS5003 wake time (ms)
+#define PMS_RETRY_COUNT 2         // Maximum retry attempts for PMS5003
 
 // DS18B20 constants
-#define DS18B20_CONVERSION_TIME_MS 750    // DS18B20 conversion time (ms)
-#define DS18B20_READ_INTERVAL_MS 10000     // DS18B20 read interval (ms)
+#define DS18B20_CONVERSION_TIME_MS 750  // DS18B20 conversion time (ms)
+#define DS18B20_READ_INTERVAL_MS 10000  // DS18B20 read interval (ms)
 
 // Type conversion limits (for overflow protection)
-#define INT16_TEMP_MAX 3276               // Max temp * 100 for int16_t (32.76°C)
-#define INT16_TEMP_MIN -3276              // Min temp * 100 for int16_t (-32.76°C)
-#define UINT16_HUMIDITY_MAX 10000         // Max humidity * 100 for uint16_t (100.00%)
-#define UINT16_PRESSURE_MAX 6553          // Max pressure * 10 for uint16_t (655.3 hPa)
-#define UINT16_IAQ_MAX 5000               // Max IAQ * 10 for uint16_t (500.0)
-#define UINT16_VOC_MAX 6000               // Max VOC * 100 for uint16_t (60.00 mg/m³)
+#define INT16_TEMP_MAX 3276        // Max temp * 100 for int16_t (32.76°C)
+#define INT16_TEMP_MIN -3276       // Min temp * 100 for int16_t (-32.76°C)
+#define UINT16_HUMIDITY_MAX 10000  // Max humidity * 100 for uint16_t (100.00%)
+#define UINT16_PRESSURE_MAX 6553   // Max pressure * 10 for uint16_t (655.3 hPa)
+#define UINT16_IAQ_MAX 5000        // Max IAQ * 10 for uint16_t (500.0)
+#define UINT16_VOC_MAX 6000        // Max VOC * 100 for uint16_t (60.00 mg/m³)
 
 // ===== DISPLAY VIEWS =====
 enum DisplayView {
   VIEW_OVERVIEW = 0,
   VIEW_ENVIRONMENT,
   VIEW_PARTICLES,
-  VIEW_GAS,      // Gas sensors
+  VIEW_GAS,  // Gas sensors
   VIEW_SYSTEM,
   VIEW_COUNT
 };
@@ -132,21 +140,21 @@ enum ErrorCode {
 #define DEBUG_ENABLED 1
 
 #if DEBUG_ENABLED
-  // Basic debug macros
-  #define DEBUG_PRINT(x) Serial.print(x)
-  #define DEBUG_PRINTLN(x) Serial.println(x)
-  #define DEBUG_PRINTF(fmt, ...) Serial.printf(fmt, ##__VA_ARGS__)
-  // Structured logging helpers for clearer output
-  #define DEBUG_INFO(fmt, ...) Serial.printf("[INFO] " fmt "\n", ##__VA_ARGS__)
-  #define DEBUG_WARN(fmt, ...) Serial.printf("[WARN] " fmt "\n", ##__VA_ARGS__)
-  #define DEBUG_ERROR(fmt, ...) Serial.printf("[ERROR] " fmt "\n", ##__VA_ARGS__)
+// Basic debug macros
+#define DEBUG_PRINT(x) Serial.print(x)
+#define DEBUG_PRINTLN(x) Serial.println(x)
+#define DEBUG_PRINTF(fmt, ...) Serial.printf(fmt, ##__VA_ARGS__)
+// Structured logging helpers for clearer output
+#define DEBUG_INFO(fmt, ...) Serial.printf("[INFO] " fmt "\n", ##__VA_ARGS__)
+#define DEBUG_WARN(fmt, ...) Serial.printf("[WARN] " fmt "\n", ##__VA_ARGS__)
+#define DEBUG_ERROR(fmt, ...) Serial.printf("[ERROR] " fmt "\n", ##__VA_ARGS__)
 #else
-  #define DEBUG_PRINT(x)
-  #define DEBUG_PRINTLN(x)
-  #define DEBUG_PRINTF(fmt, ...)
-  #define DEBUG_INFO(fmt, ...)
-  #define DEBUG_WARN(fmt, ...)
-  #define DEBUG_ERROR(fmt, ...)
+#define DEBUG_PRINT(x)
+#define DEBUG_PRINTLN(x)
+#define DEBUG_PRINTF(fmt, ...)
+#define DEBUG_INFO(fmt, ...)
+#define DEBUG_WARN(fmt, ...)
+#define DEBUG_ERROR(fmt, ...)
 #endif
 
 #endif


### PR DESCRIPTION
## Summary

- **MQTT discovery stability**: Deferred discovery to `update()` with 2s stabilization delay; added `DISCOVERY_CHECK_CONNECTED()` macro to abort mid-run on disconnect; 60s backoff retry via `nextDiscoveryRetryAt`
- **Reconnect loop fix**: Removed `discoveryPublished = false` reset in `reconnect()` — prevents the 2s online/offline flicker when the broker drops briefly
- **Broker publish reliability**: Added `delay(100)` + `mqttClient.loop()` after each individual discovery publish to prevent rapid-fire drops (e.g. port 403 brokers)
- **BME68X diagnostics**: Added `scanI2CBus()` to dump all detected I2C addresses when BME68X is not found; added 150ms power-up delay before init (shared bus with display)
- **Config cleanup**: Defined `BME68X_I2C_ADDR_LOW` / `BME68X_I2C_ADDR_HIGH` with `#ifndef` guards; fixed `DEBUG_ENABLED` macro indentation; aligned `#define` comments

## Test plan

- [ ] Flash firmware and verify Home Assistant MQTT discovery entities appear correctly on first boot
- [ ] Simulate MQTT disconnect during discovery (pull broker) — verify device recovers without 2s online/offline loop
- [ ] Verify BME68X not-found case logs I2C bus scan output to serial
- [ ] Confirm no double-discovery on reconnect after initial discovery already published
- [ ] Check 60s retry kicks in after a discovery abort